### PR TITLE
ユーザー設定がない場合の対応を追加

### DIFF
--- a/src/components/settings/UserSetting.svelte
+++ b/src/components/settings/UserSetting.svelte
@@ -3,8 +3,11 @@
 
   let loading = false;
   let selectedUserNum = 0;
+  let isIgnoreCache = false;
 
-  const getSettings = () => {};
+  const getSettings = () => {
+    isIgnoreCache = $users[selectedUserNum].localStorageOptions?.ignoreCache || false;
+  };
 
   const reGetEmojis = async () => {
     loading = true;
@@ -32,7 +35,7 @@
     >
     <input
       type="checkbox"
-      bind:checked={$users[selectedUserNum].localStorageOptions.ignoreCache}
+      bind:checked={isIgnoreCache}
       class="checkbox"
     />
   </label>


### PR DESCRIPTION
fixes #16 

ユーザー設定が存在しない（デフォルト設定値）場合のignoreCacheの決定でlocalStorageOptionsが取得できず、エラーとなっていたため、falseにfallbackするように修正しました。